### PR TITLE
Make notes, warnings, etc. nicer

### DIFF
--- a/themes/hpy/assets/css/styles.css
+++ b/themes/hpy/assets/css/styles.css
@@ -355,3 +355,7 @@ tbody tr:nth-child(odd) {
 .metadata {
     border-bottom: 1px solid darkolivegreen;
 }
+
+.admonition-title {
+    margin-top: 0px;
+}


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/344507/113050277-ef46f100-91a4-11eb-93fe-644b956ac47b.png)

after:
![image](https://user-images.githubusercontent.com/344507/113050427-1dc4cc00-91a5-11eb-926c-03516ea1d073.png)

(we should probably apply the same diff to pypy.org)