### PR TITLE
Fix positioning of mobile hamburger icon

### DIFF
--- a/themes/hpy/assets/css/styles.css
+++ b/themes/hpy/assets/css/styles.css
@@ -172,6 +172,10 @@ div.sidebar {
   margin: 0 auto;
 }
 
+.nav-container {
+  position: relative;
+}
+
 .nav-container nav {
   float: right;
   background: var(--nav-background);


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/33094578/113439310-f261fd00-93af-11eb-84d7-6d80b1eff0be.png)
After:
![image](https://user-images.githubusercontent.com/33094578/113439325-fa21a180-93af-11eb-807c-8eb6edf32439.png)

(Browser is firefox)

This shouldn't affect the desktop layout at all.