### PR TITLE
Changed visited link color to purple.

### DIFF
--- a/themes/hpy/assets/css/styles.css
+++ b/themes/hpy/assets/css/styles.css
@@ -8,7 +8,7 @@
 }
 
 :visited {
-    color: darkolivegreen;
+    color: purple;
 }
 
 .reference:hover {
@@ -25,7 +25,7 @@ pre.literal-block {
 }
 
 pre.literal-block *:last-child {
-    margin-bottom: 0; 
+    margin-bottom: 0;
 }
 
 .myfooter {
@@ -341,7 +341,7 @@ body {
 #download img {
   width: 22px;
   height: 22px;
-} 
+}
 
 table {
   border-top: 2px solid darkolivegreen;


### PR DESCRIPTION
This PR changes the visited link colour to purple, which is the standard and looks fairly good with this theme to me.

Notes:
* I also removed some trailing whitespace.
* The file `styles.min.css` hasn't been updated, but the checked in version doesn't seem to be up to date with `styles.css` anyway and doesn't seem to be used by the site. Not sure whether to just delete it from the repository or whether something else should happen.