### PR TITLE
tweak logo

### DIFF
--- a/images/hpy-logo.svg
+++ b/images/hpy-logo.svg
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Generator: Adobe Illustrator 23.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    id="Layer_1"
    x="0px"
    y="0px"
-   viewBox="0 0 277.23191 151.43341"
+   viewBox="0 0 284.41917 151.43341"
    xml:space="preserve"
    sodipodi:docname="hpy-logo.svg"
-   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
-   width="277.2319"
-   height="151.43341"><metadata
+   inkscape:version="1.2 (56b05e47e7, 2022-06-09, custom)"
+   viewport="0 0 1280px 697px"
+   width="284.41916"
+   height="151.43341"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata
    id="metadata200"><rdf:RDF><cc:Work
        rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
    id="defs198" /><sodipodi:namedview
    pagecolor="#ffffff"
    bordercolor="#666666"
@@ -31,21 +30,25 @@
    guidetolerance="10"
    inkscape:pageopacity="0"
    inkscape:pageshadow="2"
-   inkscape:window-width="1991"
-   inkscape:window-height="1569"
+   inkscape:window-width="1920"
+   inkscape:window-height="1016"
    id="namedview196"
    showgrid="false"
-   inkscape:zoom="1.28"
-   inkscape:cx="-28.440215"
-   inkscape:cy="-70.057449"
-   inkscape:window-x="1830"
-   inkscape:window-y="415"
-   inkscape:window-maximized="0"
-   inkscape:current-layer="Layer_1"
+   inkscape:zoom="2.0066888"
+   inkscape:cx="-29.152502"
+   inkscape:cy="89.450841"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g937"
    fit-margin-top="0"
    fit-margin-left="0"
    fit-margin-right="0"
-   fit-margin-bottom="0" />
+   fit-margin-bottom="0"
+   inkscape:document-rotation="0"
+   inkscape:showpageshadow="2"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1" />
 <style
    type="text/css"
    id="style2">
@@ -66,28 +69,29 @@
 
 <g
    id="g937"
-   transform="translate(-19.696368,-15.343154)"><rect
-   ry="21.035357"
+   transform="translate(-12.509134,-15.343154)"><rect
+   ry="21.035358"
    y="18.011654"
-   x="22.364868"
+   x="15.177634"
    height="136.72983"
    width="111.90734"
    id="rect1009"
-   style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#cbbec3;fill-opacity:1;stroke:#193440;stroke-width:5.33699989;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" /><g
+   style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:#daafc3;fill-opacity:1;stroke:#193440;stroke-width:5.337;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" /><g
    aria-label="H"
    style="font-style:normal;font-weight:normal;font-size:20px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#193440;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-   id="text1013"><path
+   id="text1013"
+   transform="translate(-7.1872218)"><path
      d="m 97.451871,41.176576 q 1.066667,-2 3.599999,-2.8 2.53333,-0.8 6.4,-0.8 3.86667,0 6.13333,0.666667 2.26667,0.666667 3.46667,1.6 1.2,0.933333 1.86667,2.666667 0.66666,2.266666 0.66666,6.933333 v 73.999997 q 0,3.06667 -0.26666,4.66667 -0.13334,1.46666 -1.2,3.46666 -1.86667,3.6 -10.4,3.6 -9.333336,0 -10.933336,-4.93333 -0.8,-2.26667 -0.8,-6.93333 V 96.243241 H 60.651872 v 27.199999 q 0,3.06667 -0.266666,4.66667 -0.133334,1.46666 -1.2,3.46666 -1.866667,3.6 -10.4,3.6 -9.333333,0 -10.933333,-4.93333 -0.8,-2.26667 -0.8,-6.93333 V 49.309909 q 0,-3.066666 0.133334,-4.533333 0.266666,-1.6 1.333333,-3.6 1.866667,-3.6 10.4,-3.6 9.333333,0 11.066666,4.933334 0.666666,2.266666 0.666666,6.933333 V 76.643242 H 95.985204 V 49.309909 q 0,-3.066666 0.133334,-4.533333 0.266666,-1.6 1.333333,-3.6 z"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.33332825px;font-family:'Fredoka One';-inkscape-font-specification:'Fredoka One';fill:#193440;fill-opacity:1"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.333px;font-family:'Fredoka One';-inkscape-font-specification:'Fredoka One';fill:#193440;fill-opacity:1"
      id="path823" /></g>
 <g
    aria-label="Py"
    style="font-style:normal;font-weight:normal;font-size:20px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#193440;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
    id="text1013-3"><path
      d="m 212.92832,57.309909 q 3.46666,7.066666 3.46666,15.733333 0,8.666666 -3.46666,15.733332 -3.46667,6.933334 -8.93333,11.066667 -11.06667,8.533329 -22.93334,8.533329 h -16.66666 v 15.06667 q 0,3.06667 -0.26667,4.66667 -0.13333,1.46666 -1.2,3.46666 -1.86667,3.6 -10.4,3.6 -9.33333,0 -10.93333,-4.93333 -0.8,-2.26667 -0.8,-6.93333 V 49.309909 q 0,-3.066666 0.13333,-4.533333 0.26667,-1.6 1.33333,-3.6 1.86667,-3.6 10.4,-3.6 h 28.53334 q 11.73333,0 22.8,8.533333 5.46666,4.133334 8.93333,11.2 z m -31.73333,27.466666 q 4,0 7.86666,-2.933334 3.86667,-2.933333 3.86667,-8.799999 0,-5.866667 -3.86667,-8.8 -3.86666,-3.066666 -8,-3.066666 h -16.66666 v 23.599999 z"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.33332825px;font-family:'Fredoka One';-inkscape-font-specification:'Fredoka One';fill:#193440;fill-opacity:1"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.333px;font-family:'Fredoka One';-inkscape-font-specification:'Fredoka One';fill:#193440;fill-opacity:1"
      id="path818" /><path
      d="m 289.06161,65.843242 q 7.86667,3.466667 7.86667,8.4 0,2.4 -1.06667,4.533333 -1.06666,2.133333 -1.06666,2.266666 l -34.93333,78.133329 q -1.06667,2.53333 -1.86667,3.86667 -0.66667,1.33333 -2.26667,2.53333 -1.6,1.2 -4,1.2 -2.4,0 -7.06666,-2 -7.86667,-3.46666 -7.86667,-8.26666 0,-3.2 12.8,-30.53334 L 223.06162,81.309908 q -2.66667,-4.4 -2.66667,-6.533333 0,-4.266667 7.2,-8.533333 4.53333,-2.666667 7.06667,-2.666667 2.53333,0 4.13333,1.066667 1.6,1.066667 2.26667,2.266667 0.8,1.066666 7.33333,12.399999 6.66667,11.2 12.66667,20.933332 0.66666,-2.133333 7.2,-16.399999 6.53333,-14.399999 6.93333,-15.333332 0.53333,-0.933334 1.6,-2.266667 1.73333,-2.266667 4.8,-2.266667 3.2,0 7.46666,1.866667 z"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.33332825px;font-family:'Fredoka One';-inkscape-font-specification:'Fredoka One';fill:#193440;fill-opacity:1"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.333px;font-family:'Fredoka One';-inkscape-font-specification:'Fredoka One';fill:#193440;fill-opacity:1"
      id="path820" /></g>
 </g></svg>


### PR DESCRIPTION
At the risk of starting a bikeshedding discussion...

There's one thing that has bothered me about the logo from day one, which is that these gaps were not symmetric:

![image](https://user-images.githubusercontent.com/85942/173311135-ec13656d-bdfe-4bfd-9ebe-a9f658c5cde2.png)

the PR fixes this, and makes the color a little bit less desaturated, because right now it looks super drab (but I am happy to take that part out if people hate it).