### PR TITLE
Add blog post about GraalPy team's HPy blog posts

### DIFF
--- a/posts/2022/09/hpy_on_graal.md
+++ b/posts/2022/09/hpy_on_graal.md
@@ -1,0 +1,24 @@
+<!--
+.. title: HPy on GraalPy and Matplotlib/HPy
+.. slug: hpy_on_graal_and_mpl
+.. date: 2022-09-08 15:30:00 UTC
+.. author: fangerer
+.. tags:
+.. category:
+.. link:
+.. description:
+.. type: text
+-->
+
+Recently, the
+[GraalVM Python](https://www.graalvm.org/python/) team started a series of blog
+posts on [Medium](https://medium.com/graalvm) about
+[HPy on GraalPy](https://medium.com/graalvm/hpy-better-python-c-api-in-practice-79328246e2f8)
+and about the
+[migration of Matplotlib to HPy](https://medium.com/graalvm/porting-matplotlib-from-c-api-to-hpy-aa32faa1f0b5)
+. The second blog post is in particular interesting since it not only describes
+the migration process but also shows performance numbers. The source code is
+also publicly available.
+
+<!--TEASER_END-->
+


### PR DESCRIPTION
Stepan and Mohaned recently wrote blog posts about our HPy efforts.
Since we (the GraalVM team) publish them on medium.com , we should also link them from the HPy blog.