### PR TITLE
format permalinks to only show when hovering

### DIFF
--- a/themes/hpy/assets/css/styles.css
+++ b/themes/hpy/assets/css/styles.css
@@ -377,6 +377,28 @@ tbody tr:nth-child(odd) {
   background-color: #eeeeee;
 }
 
+/* Header permalinks */
+h1:hover .headerlink, h2:hover .headerlink,
+h3:hover .headerlink, h4:hover .headerlink,
+h5:hover .headerlink, h6:hover .headerlink {
+    display: inline;
+}
+
+.headerlink {
+    display: none;
+    color: #ddd;
+    margin-left: 0.2em;
+    padding: 0 0.2em;
+}
+
+.headerlink:hover {
+    opacity: 1;
+    background: #ddd;
+    color: #000;
+    text-decoration: none;
+}
+
+
 .metadata {
   border-bottom: 1px solid darkolivegreen;
 }


### PR DESCRIPTION
Fixes #51 

Add some CSS styling to
- hide permalinks by default
- when hovering over the title, show the ¶ at the end of the line with a link

I find this convenient when trying figure out how to link to a particular paragraph in the documentation when writing another blog post/issue